### PR TITLE
fixing WSTL sample document to make it a valid json

### DIFF
--- a/index.html
+++ b/index.html
@@ -848,10 +848,10 @@ Provide a standard format for representor programmers to convert internal servic
             "name": "external",
             "prompt": "External Search?",
             "value": "",
-            "required: true,
+            "required": true,
             "suggest": [{"value":"true"},{"value":"false"}]
           }
-        }
+        ]
       }
     ],
     "data": [
@@ -867,7 +867,6 @@ Provide a standard format for representor programmers to convert internal servic
         "id": "azsxdcfvgb",
         "title": "Danny Two-Shoes"
       },
-
     ]
   }
 }</code></pre>


### PR DESCRIPTION
When trying to use the sample json code I realised it is not a valid json document. 
This pull request fixes it by adding one missing `"` and swapping one `}` for ']'. 

Additionally, and unintentionally, my IDE fixed line endings to match the rest in 3 lines. Hopefully that's not a problem. 